### PR TITLE
서버 에러 발생 시, 디스코드 채널로 에러 로그 공유 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -41,6 +42,8 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.23'
 
+	// DISCORD
+	implementation 'com.github.napstr:logback-discord-appender:1.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty name="DISCORD_WEBHOOK_URI" source="logging.discord.webhook-uri"/>
+    <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+        <webhookUri>${DISCORD_WEBHOOK_URI}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{HH:mm:ss} [%thread] [%-5level] %logger{36} - %msg%n```%ex{full}```</pattern>
+        </layout>
+        <username>기태야.. 유정아.. 에러떴다..</username>
+        <tts>false</tts>
+    </appender>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="DISCORD" />
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC_DISCORD"/>
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 🔖 Pull Request Type
- [X] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] docs: 문서 수정 또는 추가
- [ ] style: 코드 스타일 수정 (포맷, 세미콜론, 공백 등)
- [ ] refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] test: 테스트 코드 추가 또는 수정
- [ ] chore: 기타 변경 사항 (빌드, 설정 파일 수정 등)


## **📌 작업 내용 (What)**
서버 에러 발생 시, 디스코드 채널로 에러 로그 공유 기능 추가


## **🛠️ 변경 사항 (Changes)**
- `build.gradle` : 디스코드 로깅 관련 라이브러리 및 설정 추가
- `application.yml` : 디스코드 로깅 관련 환경변수 추가
-  `logback.xml` : 로깅 포맷 정의 기능 구현


## **✅ 체크리스트 (Checklist)**
- [X] 로컬에서 정상적으로 동작 확인
- [ ] main 브랜치 병합 후, 우분투 환경에서도 잘 돌아가는지 확인해봐야함.


## **🔗 관련 이슈 (Issue Links)**
X


## **🤔 리뷰 요청 사항**
- application.yml에 변경사항이 있습니다. 팀 백엔드 노션에 application.yml 수정했으니 반영 부탁드립니다:)
- 아직 application.yml 파일 관련 환경 분리를 안해놔서 로컬 환경에서도 에러가 발생하면 디스코드 채널로 날라갑니다. 개발 좀 진행되면 환경분리도 하면 좋을 것 같습니다!


## **📷 스크린샷 (Optional)**
![image](https://github.com/user-attachments/assets/5a6e32af-e57a-400c-af31-3c05fd5645ea)


---
### **🌼리뷰어 참고🌼**
- **P1**: 꼭 반영해주세요 (Request changes)
- **P2**: 적극적으로 고려해주세요 (Request changes)
- **P3**: 웬만하면 반영해 주세요 (Comment)
- **P4**: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- **P5**: 그냥 사소한 의견입니다 (Approve)
