### PR TITLE
Jacoco 라이브러리를 통한 테스트 커버리지 측정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.2'
 	id 'io.spring.dependency-management' version '1.1.6'
+	id 'jacoco'
 }
 
 group = 'TiCatch'
@@ -48,4 +49,30 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jacoco {
+	toolVersion = "0.8.9"
+}
+
+test {
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+
+	reports {
+		xml.required.set(true)
+		html.required.set(true)
+
+		afterEvaluate {
+			classDirectories.setFrom(files(classDirectories.files.collect {
+				fileTree(dir: it, include: '**/service/**')
+			}))
+		}
+
+		xml.destination file("${buildDir}/jacoco/index.xml")
+		html.destination file("${buildDir}/jacoco/index.html")
+	}
 }


### PR DESCRIPTION
## 🔖 Pull Request Type
- [X] feat: 새로운 기능 추가


## **📌 작업 내용 (What)**
- Jacoco 라이브러리를 추가해서 service 디렉토리 밑에 있는 코드에 대한 테스트 커버리지를 측정할 수 있도록 구현했습니다.


## **🛠️ 변경 사항 (Changes)**
- `build.gradle`: Jacoco 라이브러리 추가 및 커버리지 타겟 범위 설정


## **✅ 체크리스트 (Checklist)**
- [X] 로컬에서 정상적으로 동작 확인


## **🔗 관련 이슈 (Issue Links)**
X


## **🤔 리뷰 요청 사항**
X


## **📷 스크린샷 (Optional)**
build.gradle refresh 후 'Tasks -> verification -> jacocoTestReport' 클릭
![image](https://github.com/user-attachments/assets/13969a39-261a-4fe3-8105-a699eadc28e6)
build -> jacoco -> index.html 열기
![image](https://github.com/user-attachments/assets/7cc81e9b-21e1-47be-accc-7132191be2f7)
service(비즈니스 로직) 디렉토리 밑에 있는 모든 메소드(라인별) 테스트 커버리지 확인 가능
<img width="1089" alt="image" src="https://github.com/user-attachments/assets/1657a34d-59ff-4b51-894d-6fccd99ebff6" />
클릭해서 details 확인하면 라인별 어떤 라인이 테스트 코드가 작성되었고 어떤 라인이 테스트 코드가 작성이 안되었는지 확인 가능
<img width="509" alt="image" src="https://github.com/user-attachments/assets/cc1c197b-18fa-4030-bd61-966f9f389cd8" />


---
### **🌼리뷰어 참고🌼**
- **P1**: 꼭 반영해주세요 (Request changes)
- **P2**: 적극적으로 고려해주세요 (Request changes)
- **P3**: 웬만하면 반영해 주세요 (Comment)
- **P4**: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- **P5**: 그냥 사소한 의견입니다 (Approve)
