### PR TITLE
티켓팅 시작 30분이 지난 시점의 종료 기능 구현

### DIFF
--- a/src/main/java/TiCatch/backend/domain/ticketing/service/TicketingService.java
+++ b/src/main/java/TiCatch/backend/domain/ticketing/service/TicketingService.java
@@ -170,9 +170,13 @@ public class TicketingService {
     @Transactional
     @Scheduled(fixedRate = TICKETING_SCHEDULER_PERIOD)
     public void activateTicketing() {
-        List<Ticketing> ticketings = ticketingRepository.findAllByTicketingStatusAndTicketingTimeBefore(TicketingStatus.WAITING, LocalDateTime.now());
-        for(Ticketing ticketing : ticketings) {
+        List<Ticketing> activateTicketings = ticketingRepository.findAllByTicketingStatusAndTicketingTimeBefore(TicketingStatus.WAITING, LocalDateTime.now());
+        List<Ticketing> expiredTicketings = ticketingRepository.findAllByTicketingStatusAndTicketingTimeBefore(TicketingStatus.IN_PROGRESS, LocalDateTime.now().minusMinutes(30));
+        for(Ticketing ticketing : activateTicketings) {
             ticketing.changeTicketingStatus(TicketingStatus.IN_PROGRESS);
+        }
+        for(Ticketing ticketing : expiredTicketings) {
+            ticketing.changeTicketingStatus(TicketingStatus.COMPLETED);
         }
     }
 


### PR DESCRIPTION
## 🔖 Pull Request Type
- [X] feat: 새로운 기능 추가


## **📌 작업 내용 (What)**
- 티켓팅 시작 30분이 지난 티켓팅 타겟으로 종료시키는 기능을 구현했습니다.


## **✅ 체크리스트 (Checklist)**
- [X] 로컬에서 정상적으로 동작 확인

---
### **🌼리뷰어 참고🌼**
- **P1**: 꼭 반영해주세요 (Request changes)
- **P2**: 적극적으로 고려해주세요 (Request changes)
- **P3**: 웬만하면 반영해 주세요 (Comment)
- **P4**: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- **P5**: 그냥 사소한 의견입니다 (Approve)
