### PR TITLE
티켓팅 완료 후 히스토리 저장 기능 구현

### DIFF
--- a/src/main/java/TiCatch/backend/domain/history/entity/History.java
+++ b/src/main/java/TiCatch/backend/domain/history/entity/History.java
@@ -1,6 +1,6 @@
 package TiCatch.backend.domain.history.entity;
 
-import TiCatch.backend.domain.ticketing.dto.request.TicketingDto;
+import TiCatch.backend.domain.ticketing.dto.request.CompleteTicketingDto;
 import TiCatch.backend.domain.ticketing.entity.Ticketing;
 import TiCatch.backend.domain.ticketing.entity.TicketingLevel;
 import TiCatch.backend.domain.user.entity.User;
@@ -44,11 +44,11 @@ public class History extends BaseTimeEntity {
     // 티켓팅 시간
     private LocalDateTime ticketingTime;
 
-    public static History of(TicketingDto ticketingDto, User user, Ticketing ticketing) {
+    public static History of(CompleteTicketingDto completeTicketingDto, User user, Ticketing ticketing) {
         return History.builder()
                 .user(user)
                 .ticketingId(ticketing.getTicketingId())
-                .seatInfo(ticketingDto.getSeatInfo())
+                .seatInfo(completeTicketingDto.getSeatInfo())
                 .ticketingLevel(ticketing.getTicketingLevel())
                 .ticketingTime(ticketing.getTicketingTime())
                 .build();

--- a/src/main/java/TiCatch/backend/domain/history/entity/History.java
+++ b/src/main/java/TiCatch/backend/domain/history/entity/History.java
@@ -1,32 +1,57 @@
 package TiCatch.backend.domain.history.entity;
 
+import TiCatch.backend.domain.ticketing.dto.request.TicketingDto;
+import TiCatch.backend.domain.ticketing.entity.Ticketing;
+import TiCatch.backend.domain.ticketing.entity.TicketingLevel;
 import TiCatch.backend.domain.user.entity.User;
 import TiCatch.backend.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "history")
 public class History extends BaseTimeEntity {
 
-    //예매 기록 ID
+    // 예매 기록 ID
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long historyId;
 
-    //사용자
+    // 사용자
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    //예매 좌석정보
-    private String historyInfo;
+    // 티켓팅 ID
+    private Long ticketingId;
 
-    //예매 난이도
-    private int historyLevel;
+    // 예매 좌석정보
+    private String seatInfo;
+
+    // 티켓팅 난이도
+    @Enumerated(EnumType.STRING)
+    private TicketingLevel ticketingLevel;
+
+    // 티켓팅 시간
+    private LocalDateTime ticketingTime;
+
+    public static History of(TicketingDto ticketingDto, User user, Ticketing ticketing) {
+        return History.builder()
+                .user(user)
+                .ticketingId(ticketing.getTicketingId())
+                .seatInfo(ticketingDto.getSeatInfo())
+                .ticketingLevel(ticketing.getTicketingLevel())
+                .ticketingTime(ticketing.getTicketingTime())
+                .build();
+    }
+
 }

--- a/src/main/java/TiCatch/backend/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/TiCatch/backend/domain/history/repository/HistoryRepository.java
@@ -1,4 +1,7 @@
 package TiCatch.backend.domain.history.repository;
 
-public interface HistoryRepository {
+import TiCatch.backend.domain.history.entity.History;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HistoryRepository extends JpaRepository<History, Long> {
 }

--- a/src/main/java/TiCatch/backend/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/TiCatch/backend/domain/history/repository/HistoryRepository.java
@@ -2,6 +2,8 @@ package TiCatch.backend.domain.history.repository;
 
 import TiCatch.backend.domain.history.entity.History;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface HistoryRepository extends JpaRepository<History, Long> {
 }

--- a/src/main/java/TiCatch/backend/domain/ticketing/controller/TicketingController.java
+++ b/src/main/java/TiCatch/backend/domain/ticketing/controller/TicketingController.java
@@ -1,6 +1,8 @@
 package TiCatch.backend.domain.ticketing.controller;
 
 import TiCatch.backend.domain.ticketing.dto.request.CreateTicketingDto;
+import TiCatch.backend.domain.ticketing.dto.request.CompleteTicketingDto;
+import TiCatch.backend.domain.ticketing.dto.response.TicketingCompleteResponseDto;
 import TiCatch.backend.domain.ticketing.dto.response.TicketingResponseDto;
 import TiCatch.backend.domain.ticketing.dto.response.TicketingWaitingResponseDto;
 import TiCatch.backend.domain.ticketing.service.TicketingService;
@@ -84,5 +86,14 @@ public class TicketingController {
     public ResponseEntity<SingleResponseResult<String>> checkSeatAvailability(@PathVariable("ticketingId") Long ticketingId, @PathVariable String seatKey) {
         ticketingService.isAvailable(ticketingId, seatKey);
         return ResponseEntity.ok(new SingleResponseResult<>("예매가 가능한 좌석입니다."));
+    }
+
+    //티켓팅 완료 후 히스토리에 저장
+    @PostMapping("/complete")
+    public ResponseEntity<SingleResponseResult<TicketingCompleteResponseDto>> completeTicketing(
+            HttpServletRequest request, @RequestBody CompleteTicketingDto completeTicketingDto) {
+        User user = userService.getUserFromRequest(request);
+        TicketingCompleteResponseDto response = ticketingService.ticketingComplete(completeTicketingDto, user);
+        return ResponseEntity.ok(new SingleResponseResult<>(response));
     }
 }

--- a/src/main/java/TiCatch/backend/domain/ticketing/dto/request/CompleteTicketingDto.java
+++ b/src/main/java/TiCatch/backend/domain/ticketing/dto/request/CompleteTicketingDto.java
@@ -1,0 +1,15 @@
+package TiCatch.backend.domain.ticketing.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompleteTicketingDto {
+    private Long ticketingId;
+    private String seatInfo;
+}

--- a/src/main/java/TiCatch/backend/domain/ticketing/dto/response/TicketingCompleteResponseDto.java
+++ b/src/main/java/TiCatch/backend/domain/ticketing/dto/response/TicketingCompleteResponseDto.java
@@ -1,0 +1,41 @@
+package TiCatch.backend.domain.ticketing.dto.response;
+
+import TiCatch.backend.domain.history.entity.History;
+import TiCatch.backend.domain.ticketing.entity.Ticketing;
+import TiCatch.backend.domain.ticketing.entity.TicketingLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class TicketingCompleteResponseDto {
+    private Long userId;
+    private Long ticketingId;
+    private TicketingLevel ticketingLevel;
+    private String seatInfo;
+    private LocalDateTime ticketingStartTime;
+    private LocalDateTime ticketingEndTime;
+
+    @Builder
+    private TicketingCompleteResponseDto(Long userId, Long ticketingId, TicketingLevel ticketingLevel,
+                                         String seatInfo, LocalDateTime ticketingStartTime, LocalDateTime ticketingEndTime) {
+        this.userId = userId;
+        this.ticketingId = ticketingId;
+        this.ticketingLevel = ticketingLevel;
+        this.seatInfo = seatInfo;
+        this.ticketingStartTime = ticketingStartTime;
+        this.ticketingEndTime = ticketingEndTime;
+    }
+
+    public static TicketingCompleteResponseDto of(Ticketing ticketing, History history) {
+        return TicketingCompleteResponseDto.builder()
+                .userId(ticketing.getUser().getUserId())
+                .ticketingId(ticketing.getTicketingId())
+                .ticketingLevel(ticketing.getTicketingLevel())
+                .seatInfo(history.getSeatInfo())
+                .ticketingStartTime(ticketing.getTicketingTime())
+                .ticketingEndTime(history.getCreatedDate())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔖 Pull Request Type
- [x] feat: 새로운 기능 추가

## **📌 작업 내용 (What)**
- 티켓팅 완료 후 히스토리 저장 기능 구현
- 티켓팅 완료 후 티켓팅 상태 COMPLETED로 변경하도록 구현

## **🛠️ 변경 사항 (Changes)**
- `History` 에 티켓팅 ID, 좌석정보, 티켓팅 시작 시간 추가

## **✅ 체크리스트 (Checklist)**
- [x] 로컬에서 정상적으로 동작 확인

## **📷 스크린샷 (Optional)**
<img width="764" alt="스크린샷 2025-02-04 오후 10 43 00" src="https://github.com/user-attachments/assets/8798167c-44dc-4caf-8766-31b5ddadf888" />



---
### **🌼리뷰어 참고🌼**
- **P1**: 꼭 반영해주세요 (Request changes)
- **P2**: 적극적으로 고려해주세요 (Request changes)
- **P3**: 웬만하면 반영해 주세요 (Comment)
- **P4**: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- **P5**: 그냥 사소한 의견입니다 (Approve)

