### PR TITLE
티켓팅 종료 시, 좌석 삭제 및 티켓팅 점수 기록에 저장

### DIFF
--- a/src/main/java/TiCatch/backend/domain/history/entity/History.java
+++ b/src/main/java/TiCatch/backend/domain/history/entity/History.java
@@ -41,16 +41,20 @@ public class History extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private TicketingLevel ticketingLevel;
 
+    // 티켓팅 점수
+    private int ticketingScore;
+
     // 티켓팅 시간
     private LocalDateTime ticketingTime;
 
-    public static History of(CompleteTicketingDto completeTicketingDto, User user, Ticketing ticketing) {
+    public static History of(CompleteTicketingDto completeTicketingDto, User user, Ticketing ticketing, int ticketingScore) {
         return History.builder()
                 .user(user)
                 .ticketingId(ticketing.getTicketingId())
                 .seatInfo(completeTicketingDto.getSeatInfo())
                 .ticketingLevel(ticketing.getTicketingLevel())
                 .ticketingTime(ticketing.getTicketingTime())
+                .ticketingScore(ticketingScore)
                 .build();
     }
 

--- a/src/main/java/TiCatch/backend/domain/ticketing/dto/response/TicketingCompleteResponseDto.java
+++ b/src/main/java/TiCatch/backend/domain/ticketing/dto/response/TicketingCompleteResponseDto.java
@@ -14,16 +14,18 @@ public class TicketingCompleteResponseDto {
     private Long ticketingId;
     private TicketingLevel ticketingLevel;
     private String seatInfo;
+    private int ticketingScore;
     private LocalDateTime ticketingStartTime;
     private LocalDateTime ticketingEndTime;
 
     @Builder
     private TicketingCompleteResponseDto(Long userId, Long ticketingId, TicketingLevel ticketingLevel,
-                                         String seatInfo, LocalDateTime ticketingStartTime, LocalDateTime ticketingEndTime) {
+                                         String seatInfo, int ticketingScore, LocalDateTime ticketingStartTime, LocalDateTime ticketingEndTime) {
         this.userId = userId;
         this.ticketingId = ticketingId;
         this.ticketingLevel = ticketingLevel;
         this.seatInfo = seatInfo;
+        this.ticketingScore = ticketingScore;
         this.ticketingStartTime = ticketingStartTime;
         this.ticketingEndTime = ticketingEndTime;
     }
@@ -34,6 +36,7 @@ public class TicketingCompleteResponseDto {
                 .ticketingId(ticketing.getTicketingId())
                 .ticketingLevel(ticketing.getTicketingLevel())
                 .seatInfo(history.getSeatInfo())
+                .ticketingScore(history.getTicketingScore())
                 .ticketingStartTime(ticketing.getTicketingTime())
                 .ticketingEndTime(history.getCreatedDate())
                 .build();

--- a/src/main/java/TiCatch/backend/domain/ticketing/service/TicketingService.java
+++ b/src/main/java/TiCatch/backend/domain/ticketing/service/TicketingService.java
@@ -222,6 +222,8 @@ public class TicketingService {
         dynamicScheduler.stopScheduler(ticketing.getTicketingId());
         log.info("@@@ 좌석 예약 알고리즘 중지: Ticketing ID={}", ticketing.getTicketingId());
 
+        redisTemplate.delete(TICKETING_SEAT_PREFIX + ticketing.getTicketingId());
+
         return TicketingCompleteResponseDto.of(ticketing, history);
     }
 }

--- a/src/main/java/TiCatch/backend/domain/ticketing/service/TicketingService.java
+++ b/src/main/java/TiCatch/backend/domain/ticketing/service/TicketingService.java
@@ -227,6 +227,7 @@ public class TicketingService {
 
         ticketing.changeTicketingStatus(TicketingStatus.COMPLETED);
         History history = historyRepository.save(History.of(completeTicketingDto, user, ticketing,ticketingScore));
+        user.updateUserScore(ticketingScore);
 
         // 티켓팅 완료 시, 좌석 예약 알고리즘 멈춤
         dynamicScheduler.stopScheduler(ticketing.getTicketingId());

--- a/src/main/java/TiCatch/backend/domain/ticketing/service/TicketingService.java
+++ b/src/main/java/TiCatch/backend/domain/ticketing/service/TicketingService.java
@@ -206,6 +206,7 @@ public class TicketingService {
             throw new UnAuthorizedTicketAccessException();
         }
         ticketing.changeTicketingStatus(TicketingStatus.CANCELED);
+        redisTemplate.delete(TICKETING_SEAT_PREFIX + ticketing.getTicketingId());
         return TicketingResponseDto.of(ticketing);
     }
 

--- a/src/main/java/TiCatch/backend/domain/user/entity/User.java
+++ b/src/main/java/TiCatch/backend/domain/user/entity/User.java
@@ -43,4 +43,8 @@ public class User extends BaseTimeEntity {
                 .userEmail(credential.getEmail())
                 .build();
     }
+
+    public void updateUserScore(int score){
+        this.userScore += score;
+    }
 }


### PR DESCRIPTION
## 🔖 Pull Request Type
- [x] feat: 새로운 기능 추가

## **📌 작업 내용 (What)**
- 티켓팅 취소/종료시 Redis에 저장된 좌석 데이터 삭제
- 티켓팅 종료 시 점수 저장하도록 수정

## **🛠️ 변경 사항 (Changes)**
`TicketingService`: 티켓팅 취소/종료시 Redis에 저장된 좌석 데이터 삭제
`History`: `ticketingScore` 추가하고, 티켓팅 종료 시 점수 저장하도록 수정
`MakeSeatWeight`: Redis에 좌석별 가중치 점수 저장하도록 추가 

## **✅ 체크리스트 (Checklist)**
- [x] 로컬에서 정상적으로 동작 확인

---
### **🌼리뷰어 참고🌼**
- **P1**: 꼭 반영해주세요 (Request changes)
- **P2**: 적극적으로 고려해주세요 (Request changes)
- **P3**: 웬만하면 반영해 주세요 (Comment)
- **P4**: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- **P5**: 그냥 사소한 의견입니다 (Approve)
