### PR TITLE
TicktingTime의 스케줄러 기반 로직 -> 이벤트 기반 로직 리팩토링

### DIFF
--- a/src/main/java/TiCatch/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/TiCatch/backend/domain/auth/controller/AuthController.java
@@ -4,7 +4,7 @@ import TiCatch.backend.domain.auth.dto.TokenDto;
 import TiCatch.backend.domain.auth.dto.response.LoginResponseDto;
 import TiCatch.backend.domain.auth.dto.response.UserResDto;
 import TiCatch.backend.domain.auth.service.KakaoAuthService;
-import TiCatch.backend.domain.auth.service.RedisService;
+import TiCatch.backend.global.service.redis.RedisService;
 import TiCatch.backend.domain.auth.util.HeaderUtil;
 import TiCatch.backend.global.response.SingleResponseResult;
 import jakarta.servlet.http.Cookie;

--- a/src/main/java/TiCatch/backend/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/TiCatch/backend/domain/auth/service/KakaoAuthService.java
@@ -11,19 +11,13 @@ import TiCatch.backend.domain.user.entity.CredentialRole;
 import TiCatch.backend.domain.user.repository.CredentialRepository;
 import TiCatch.backend.domain.user.repository.UserRepository;
 import TiCatch.backend.global.exception.UnAuthorizedAccessException;
+import TiCatch.backend.global.service.redis.RedisService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
@@ -36,11 +30,8 @@ import org.springframework.web.client.RestTemplate;
 import TiCatch.backend.domain.user.entity.User;
 import TiCatch.backend.global.exception.NotExistUserException;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/src/main/java/TiCatch/backend/domain/ticketing/repository/TicketingRepository.java
+++ b/src/main/java/TiCatch/backend/domain/ticketing/repository/TicketingRepository.java
@@ -10,5 +10,4 @@ import java.util.List;
 
 @Repository
 public interface TicketingRepository extends JpaRepository<Ticketing, Long> {
-    List<Ticketing> findAllByTicketingStatusAndTicketingTimeBefore(TicketingStatus ticketingStatus, LocalDateTime now);
 }

--- a/src/main/java/TiCatch/backend/domain/ticketing/service/TicketingBatchProcessService.java
+++ b/src/main/java/TiCatch/backend/domain/ticketing/service/TicketingBatchProcessService.java
@@ -1,6 +1,6 @@
 package TiCatch.backend.domain.ticketing.service;
 
-import TiCatch.backend.domain.auth.service.RedisService;
+import TiCatch.backend.global.service.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.ZSetOperations;

--- a/src/main/java/TiCatch/backend/global/config/RedisConfig.java
+++ b/src/main/java/TiCatch/backend/global/config/RedisConfig.java
@@ -78,7 +78,7 @@ public class RedisConfig {
 		return new ReactiveRedisTemplate<>(factory, serializationContext);
 	}
 
-	// ✅ Key Expiry 이벤트 감지를 위한 RedisMessageListenerContainer 추가
+	// Key Expiry 이벤트 감지를 위한 RedisMessageListenerContainer 추가
 	@Bean
 	public RedisMessageListenerContainer redisMessageListenerContainer(
 			RedisConnectionFactory connectionFactory,

--- a/src/main/java/TiCatch/backend/global/config/RedisConfig.java
+++ b/src/main/java/TiCatch/backend/global/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package TiCatch.backend.domain.auth.config;
+package TiCatch.backend.global.config;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,8 +11,13 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import TiCatch.backend.global.service.redis.RedisExpirationListener;
 
 @Configuration
 public class RedisConfig {
@@ -27,15 +32,14 @@ public class RedisConfig {
 	private String redisPassword;
 
 	@Bean
-	@Primary  // RedisTemplate을 기본으로 설정
+	@Primary  // 기본 Redis 연결 설정
 	public RedisConnectionFactory redisConnectionFactory() {
 		RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
 		redisStandaloneConfiguration.setHostName(redisHost);
 		redisStandaloneConfiguration.setPort(Integer.parseInt(redisPort));
 		redisStandaloneConfiguration.setPassword(redisPassword);
 
-		LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
-		return lettuceConnectionFactory;
+		return new LettuceConnectionFactory(redisStandaloneConfiguration);
 	}
 
 	@Bean
@@ -47,7 +51,7 @@ public class RedisConfig {
 		return new LettuceConnectionFactory(redisStandaloneConfiguration);
 	}
 
-	// redis-cli 사용을 위한 설정
+	// RedisTemplate 설정 (동기 방식)
 	@Bean
 	@Qualifier("redisTemplate")
 	public RedisTemplate<String, Object> redisTemplate() {
@@ -58,8 +62,7 @@ public class RedisConfig {
 		return redisTemplate;
 	}
 
-
-	// 비동기 방식의 ReactiveRedisTemplate 추가
+	// ReactiveRedisTemplate 설정 (비동기 방식)
 	@Bean
 	@Qualifier("reactiveRedisTemplate")
 	public ReactiveRedisTemplate<String, String> reactiveRedisTemplate(
@@ -73,5 +76,19 @@ public class RedisConfig {
 				.build();
 
 		return new ReactiveRedisTemplate<>(factory, serializationContext);
+	}
+
+	// ✅ Key Expiry 이벤트 감지를 위한 RedisMessageListenerContainer 추가
+	@Bean
+	public RedisMessageListenerContainer redisMessageListenerContainer(
+			RedisConnectionFactory connectionFactory,
+			RedisExpirationListener redisExpirationListener) {
+
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		container.addMessageListener(new MessageListenerAdapter(redisExpirationListener),
+				new PatternTopic("__keyevent@0__:expired")); // 0번 DB 기준
+
+		return container;
 	}
 }

--- a/src/main/java/TiCatch/backend/global/constant/RedisConstants.java
+++ b/src/main/java/TiCatch/backend/global/constant/RedisConstants.java
@@ -3,6 +3,8 @@ package TiCatch.backend.global.constant;
 public class RedisConstants {
     public static final String WAITING_QUEUE_PREFIX = "queue:ticket:";
     public static final String TICKETING_SEAT_PREFIX = "ticketingId:";
+    public static final String TICKETING_CONTROL_PREFIX = "controlQueue";
+    public static final String TIME_TO_LIVE_PREFIX = "timeToLive:";
     public static final int RANGE_START_INDEX = 0;
     public static final int EXPIRE_TIMEOUT = 14;
 }

--- a/src/main/java/TiCatch/backend/global/constant/RedisConstants.java
+++ b/src/main/java/TiCatch/backend/global/constant/RedisConstants.java
@@ -3,8 +3,7 @@ package TiCatch.backend.global.constant;
 public class RedisConstants {
     public static final String WAITING_QUEUE_PREFIX = "queue:ticket:";
     public static final String TICKETING_SEAT_PREFIX = "ticketingId:";
-    public static final String TICKETING_CONTROL_PREFIX = "controlQueue";
-    public static final String TIME_TO_LIVE_PREFIX = "timeToLive:";
+    public static final String TIME_TO_LIVE_PREFIX = "expired";
     public static final int RANGE_START_INDEX = 0;
     public static final int EXPIRE_TIMEOUT = 14;
 }

--- a/src/main/java/TiCatch/backend/global/service/redis/RedisExpirationListener.java
+++ b/src/main/java/TiCatch/backend/global/service/redis/RedisExpirationListener.java
@@ -1,0 +1,17 @@
+package TiCatch.backend.global.service.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisExpirationListener implements MessageListener {
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String expiredKey = message.toString();
+        System.out.println(expiredKey + "기태태태");
+    }
+}

--- a/src/main/java/TiCatch/backend/global/service/redis/RedisExpirationListener.java
+++ b/src/main/java/TiCatch/backend/global/service/redis/RedisExpirationListener.java
@@ -9,15 +9,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RedisExpirationListener implements MessageListener {
 
     private final DynamicScheduler dynamicScheduler;
     private final TicketingRepository ticketingRepository;
 
     @Override
+    @Transactional
     public void onMessage(Message message, byte[] pattern) {
         String expiredMessageKey = message.toString();
         TicketingStatus ticketingStatus = TicketingStatus.valueOf(expiredMessageKey.split(":")[0]);

--- a/src/main/java/TiCatch/backend/global/service/redis/RedisExpirationListener.java
+++ b/src/main/java/TiCatch/backend/global/service/redis/RedisExpirationListener.java
@@ -1,5 +1,10 @@
 package TiCatch.backend.global.service.redis;
 
+import TiCatch.backend.domain.ticketing.entity.Ticketing;
+import TiCatch.backend.domain.ticketing.entity.TicketingStatus;
+import TiCatch.backend.domain.ticketing.repository.TicketingRepository;
+import TiCatch.backend.global.config.DynamicScheduler;
+import TiCatch.backend.global.exception.NotExistTicketException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -9,9 +14,21 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RedisExpirationListener implements MessageListener {
 
+    private final DynamicScheduler dynamicScheduler;
+    private final TicketingRepository ticketingRepository;
+
     @Override
     public void onMessage(Message message, byte[] pattern) {
-        String expiredKey = message.toString();
-        System.out.println(expiredKey + "기태태태");
+        String expiredMessageKey = message.toString();
+        TicketingStatus ticketingStatus = TicketingStatus.valueOf(expiredMessageKey.split(":")[0]);
+        Long expiredTicketingId = Long.valueOf(expiredMessageKey.split(":")[1]);
+        Ticketing ticketing = ticketingRepository.findById(expiredTicketingId).orElseThrow(NotExistTicketException::new);
+
+        if(ticketingStatus.equals(TicketingStatus.IN_PROGRESS)) {
+            ticketing.changeTicketingStatus(TicketingStatus.IN_PROGRESS);
+            dynamicScheduler.startTicketingScheduler(ticketing.getTicketingId(),ticketing.getTicketingLevel());
+        } else {
+            ticketing.changeTicketingStatus(TicketingStatus.COMPLETED);
+        }
     }
 }

--- a/src/main/java/TiCatch/backend/global/service/redis/RedisService.java
+++ b/src/main/java/TiCatch/backend/global/service/redis/RedisService.java
@@ -1,5 +1,6 @@
 package TiCatch.backend.global.service.redis;
 
+import TiCatch.backend.domain.ticketing.entity.TicketingStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -30,12 +31,8 @@ public class RedisService {
 		redisTemplate.opsForZSet().add(queueKey, userId, score);
 	}
 
-	public void addToControlQueue(Long ticketId, long ticketingTime) {
-		redisTemplate.opsForZSet().add(TICKETING_CONTROL_PREFIX, String.valueOf(ticketId), ticketingTime);
-	}
-
-	public void addExpiryToControlQueue(Long ticketId, long ttl) {
-		redisTemplate.opsForValue().set(TIME_TO_LIVE_PREFIX + ticketId, String.valueOf(ticketId),  ttl, TimeUnit.SECONDS);
+	public void addExpiryToControlQueue(Long ticketId, long ttl, TicketingStatus ticketingStatus) {
+		redisTemplate.opsForValue().set(ticketingStatus + ":" + ticketId, TIME_TO_LIVE_PREFIX,  ttl, TimeUnit.SECONDS);
 	}
 
 	public void deleteWaitingQueue(Long ticketId) {

--- a/src/main/java/TiCatch/backend/global/service/redis/RedisService.java
+++ b/src/main/java/TiCatch/backend/global/service/redis/RedisService.java
@@ -1,4 +1,4 @@
-package TiCatch.backend.domain.auth.service;
+package TiCatch.backend.global.service.redis;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +28,14 @@ public class RedisService {
 		String queueKey = WAITING_QUEUE_PREFIX + ticketId;
 		double score = System.currentTimeMillis();
 		redisTemplate.opsForZSet().add(queueKey, userId, score);
+	}
+
+	public void addToControlQueue(Long ticketId, long ticketingTime) {
+		redisTemplate.opsForZSet().add(TICKETING_CONTROL_PREFIX, String.valueOf(ticketId), ticketingTime);
+	}
+
+	public void addExpiryToControlQueue(Long ticketId, long ttl) {
+		redisTemplate.opsForValue().set(TIME_TO_LIVE_PREFIX + ticketId, String.valueOf(ticketId),  ttl, TimeUnit.SECONDS);
 	}
 
 	public void deleteWaitingQueue(Long ticketId) {


### PR DESCRIPTION
## 🔖 Pull Request Type
- [X] refactor: 코드 리팩토링 (기능 변경 없음)


## **📌 작업 내용 (What)**
1. 전역적으로 사용하는 Redis 관련 클래스들을 auth 디렉토리 밑에서 global 밑으로 옮겼습니다.
2. 1초마다 도는 스케줄러를 삭제하고 Redis의 ExpiredKeyListener 기술을 활용해 이벤트 기반 로직으로 리팩토링 했습니다.

Ticketing을 생성할 때 TicketingTime의 TTL 1개, TicketingTime+30분의 TTL 1개 총 2개를 Redis의 Expire를 활용해 넣어둡니다.
해당 TTL이 만료되면서 RedisListener는 만료된 TicketingId를 읽어오고 기존에 스케줄러에서 수행한 작업을 진행합니다.
1초마다 도는 스케줄러로 인한 비효율적인 DB 탐색, 로깅 리팩토링 완료


## **✅ 체크리스트 (Checklist)**
- [X] 로컬에서 정상적으로 동작 확인


## **🤔 리뷰 요청 사항**
- 기존에 RedisConfig, RedisService 등이 auth 디렉토리 밑에 있었는데 auth 로직뿐만 아니라 ticketing 로직 등 전역적으로 사용되고있어서 global로 뺐습니다. Redis 관련해서 작업하신 부분이 많으니 빼먹은거 없는지 확인 부탁드립니다:)


## **📷 스크린샷 (Optional)**
redis-cli에서 TTL `{TicketingStatus}:{TicketingId}`로 현재 남은 TTL 확인 가능
예시는 티켓팅 생성 후 1분 뒤에 시작하는 티켓팅을 조회 `TTL IN_PROGRESS:22` 한 결과값
종료되는 티켓팅을 조회하려면 `TTL COMPLETED:22`로 확인 가능
![스크린샷 2025-02-26 오전 4 26 22](https://github.com/user-attachments/assets/b9769410-6a97-4cfa-bd60-c2aa1c28063c)
![image](https://github.com/user-attachments/assets/4d614431-89b4-4381-9af3-8d11dd244671)

기존에 1초마다 찍히는 로깅없이 TTL이 0이 되었을 때 ticketing의 dyanmic 스케줄러가 실행되는 모습 확인 가능
<img width="1763" alt="image" src="https://github.com/user-attachments/assets/41fb1894-645b-4067-aa35-a0b5de79dd9f" />


---
### **🌼리뷰어 참고🌼**
- **P1**: 꼭 반영해주세요 (Request changes)
- **P2**: 적극적으로 고려해주세요 (Request changes)
- **P3**: 웬만하면 반영해 주세요 (Comment)
- **P4**: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- **P5**: 그냥 사소한 의견입니다 (Approve)
